### PR TITLE
Remove Electron token from the user agent

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,14 @@ electron.app.commandLine.appendSwitch(
 
 electron.app.commandLine.appendSwitch("disable-site-isolation-trials")
 
+// Some sites sniff the user agent and refuse to render for anything they do not
+// recognise as a supported desktop browser (Motorola WebDispatcher, for example,
+// shows "Browser not supported"). Dropping the `Electron/<version>` token leaves
+// an ordinary Chrome UA and is enough to pass those checks. The
+// `webapp-display/<version>` token is kept so devices stay identifiable.
+const defaultUserAgent = electron.app.userAgentFallback
+electron.app.userAgentFallback = defaultUserAgent.replace(/Electron\/[\d.]+\s*/, "")
+
 if (process.platform === "darwin") {
   electron.systemPreferences.askForMediaAccess("camera")
   electron.systemPreferences.askForMediaAccess("microphone")
@@ -49,6 +57,8 @@ electron.protocol.registerSchemesAsPrivileged([
 ])
 
 electron.app.on("ready", async () => {
+  logger.info(`User agent: ${electron.app.userAgentFallback} (was: ${defaultUserAgent})`)
+
   const { mqttClient, queryConfig, data } = await bootstrap(config.bootstrapUrl, SERVICE_ID)
 
   const httpAuthCredentials = await loadHttpAuth(queryConfig, config.httpAuth)


### PR DESCRIPTION
## Problem

Web apps that sniff the user agent for a known desktop browser refuse to render in webapp-display.

The example use case "WebDispatcher" (e.g. https://example.com/with-user-agent-checks)

```
devices/HM-Wall-P1/doStartWebApp  {"uri": "https://example.com/with-user-agent-checks"}
```

The page loads and its JS boots, but the website renders a **"Browser not supported"** notice instead of its sign-on page, so the webApp never becomes usable.

## Cause

Electron's default user agent advertises itself:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) webapp-display/4.11.17 Chrome/134.0.6998.88 Electron/35.0.2 Safari/537.36
```

WebDispatcher's browser check does not recognise `Electron/35.0.2` and falls through to its unsupported-browser page. There was no user agent handling anywhere in `src/` before this change.

## Fix

One line, in `src/main.js`:

```js
electron.app.userAgentFallback = defaultUserAgent.replace(/Electron\/[\d.]+\s*/, "")
```

Resulting user agent:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) webapp-display/4.11.17 Chrome/134.0.6998.88 Safari/537.36
```

Plus one `logger.info` on startup recording the resolved and original user agent, so a future UA problem is visible in the log file rather than needing a rebuild to diagnose.

## Why this shape

- **Only the `Electron/<version>` token is removed.** This was verified empirically, not assumed: with the token removed and `webapp-display/4.11.17` still present, WebDispatcher renders its sign-on page. Stripping the app token as well was tested and is not necessary, so it is not done.
- **`webapp-display/<version>` is kept deliberately.** It is what identifies our devices in backend and proxy logs; removing it would have been a silent, unrelated behaviour change.
- **`userAgentFallback` rather than per-window `setUserAgent`.** It is the process-wide default, so it covers the compositor page, its `iframe` layers and its `webview` layers uniformly, including windows recreated by `doClearCacheAndRestart`. No call site has to remember to set it.

## Risk

Low, and deliberately bounded.

- The regex is anchored to the literal `Electron/` token. If a future Electron version stops emitting it, the replace is a no-op and the user agent is unchanged — it cannot corrupt the string.
- Set once at module load, before `app.on("ready")` and before any window exists, so there is no window that briefly uses the old value.
- Nothing else in this repo reads or branches on the user agent (`grep -rn userAgent src/` → only this change). Device emulation only sets viewport, scale and the `mobile` flag; it does not touch the UA.
- No other project in the tour stack keys off `Electron` or `webapp-display` in a user agent — checked across the sibling repos.
- Purely additive: 10 lines, no existing line modified, no dependency added, no config change. `npm run lint` passes.

## Verification

Reproduced and verified end to end on macOS against a local stack (mosquitto with a TCP + WebSocket listener, a stand-in bootstrap server, and webapp-compositor on `:8080`), with the display bootstrapped as `HM-Wall-P1`:

| | Before | After |
|---|---|---|
| `doStartWebApp` → WebDispatcher | "Browser not supported" | Sign-on page renders |

Also re-checked that ordinary sites still start and transition normally (`https://www.wikipedia.org/` with `"transition": "fade"`).

One cosmetic notice remains on the WebDispatcher page — *"Dispatch runs on a system with Windows OS"*. That is the site's own OS check, it is not a blocker, and it will not appear on the Windows display devices.

## Not included

Two things were found while diagnosing this and are deliberately left out to keep this change minimal. Both can follow separately:

1. `loadInteractions` returns `undefined` when no interactions are configured, so `WebpageInteractor` throws an unhandled rejection on *every* completed network request (`src/interactions.js:18`). Pre-existing on master, unrelated to the user agent.
2. A `dev/` folder with the local broker + bootstrap stub used to reproduce this without the internal backend.
